### PR TITLE
chore: include psql in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ FROM base
 
 # Install packages needed for deployment
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libsqlite3-0 libpq-dev neovim && \
+    apt-get install --no-install-recommends -y curl libsqlite3-0 libpq-dev postgresql-client neovim && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Copy built artifacts: gems, application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+    ports:
+      - "5432:5432"
 
 networks:
   gym_trackr_network:


### PR DESCRIPTION
psql client was included into the final base image and the port 5432 was exposed in the docker compose

### Ticket(s)
[Jira ticket](https://gymtrackr.atlassian.net/browse/SCRUM-8)

## Todos

- [x] PR conforms to our git guidelines
- [x] PR is linked with its corresponding Jira ticket(s)
- [x] PR was added to the corresponding field in the Jira ticket(s)