### PR TITLE
feat(graphql): add test environment setup and improve sign up flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ install:
 	bundle exec rails db:create && \
 	bundle exec rails db:migrate && \
 	bundle exec rails db:seed"
+	docker compose run --rm app_test bash -c "\
+	bundle install && \
+	bundle exec rails db:drop && \
+	bundle exec rails db:create && \
+	bundle exec rails db:migrate
 
 .PHONY: bundle
 bundle:
@@ -17,7 +22,6 @@ console:
 
 .PHONY: server
 server:
-	rm -f rails/tmp/pids/server.pid
 	docker compose up app
 
 .PHONY: db.migrate
@@ -51,5 +55,9 @@ bash:
 
 .PHONY: test
 test:
-	docker compose run --rm app bundle exec rspec
+	docker compose run --rm app_test bundle exec rspec
+
+.PHONY: test.session
+test.session:
+	docker compose run --rm app_test bash
 

--- a/app/graphql/errors/sign_up_error.rb
+++ b/app/graphql/errors/sign_up_error.rb
@@ -1,0 +1,7 @@
+module Errors
+  class SignUpError < GraphQL::ExecutionError
+    def initialize(message)
+      super "Sign up error: #{message}"
+    end
+  end
+end

--- a/app/graphql/mutations/authentication/sign_up.rb
+++ b/app/graphql/mutations/authentication/sign_up.rb
@@ -11,7 +11,6 @@ module Mutations
       argument :type, String, required: true
 
       field :user, Types::UserType, null: true
-      field :errors, [String], null: true
 
       def resolve(name:, surname:, phone:, address:, email:, password:, password_confirmation:, type:)
         authenticatable = set_authenticatable(name, surname, phone, address, type)
@@ -24,11 +23,9 @@ module Mutations
           authenticatable: authenticatable
         )
 
-        if user.save
-          {user: user, errors: nil}
-        else
-          {user: nil, errors: user.errors.full_messages}
-        end
+        raise Errors::SignUpError.new(user.errors.full_messages.join(", ")) unless user.save
+
+        { user: user }
       end
 
       private

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -2,7 +2,10 @@
 
 # If running the rails server then create or migrate existing database
 if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
-  ./bin/rails db:prepare
+    ./bin/rails db:prepare
 fi
+
+echo "Configuring the database..."
+bundle exec rails db:setup
 
 exec "${@}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       db:
         condition: service_healthy
     tty: true
-    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    command: 'bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b 0.0.0.0"'
     volumes:
       - .:/rails
       - bundle_data:/usr/local/bundle
@@ -40,6 +40,46 @@ services:
     ports:
       - "5432:5432"
 
+  app_test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: gym_tracker-test
+    init: true
+    depends_on:
+      db_test:
+        condition: service_healthy
+    tty: true
+    command: bundle exec rails s -p 3001 -b '0.0.0.0'
+    volumes:
+      - .:/rails
+      - bundle_data_test:/usr/local/bundle
+    ports:
+      - "3001:3000"
+    environment:
+      RAILS_ENV: test
+      DATABASE_URL: postgres://postgres:password@db:5432/gym_trackr_test
+    networks:
+      - gym_trackr_network
+
+  db_test:
+    image: postgres:latest
+    volumes:
+      - postgres_data_test:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: gym_trackr_test
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    networks:
+      - gym_trackr_network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    ports:
+      - "5433:5432"
+
   pgadmin:
     image: dpage/pgadmin4
     container_name: pgadmin4_container
@@ -60,5 +100,7 @@ networks:
 
 volumes:
   postgres_data:
+  postgres_data_test:
   pgadmin_data:
   bundle_data:
+  bundle_data_test:

--- a/spec/requests/graphql/mutations/users/sign_up_spec.rb
+++ b/spec/requests/graphql/mutations/users/sign_up_spec.rb
@@ -1,59 +1,50 @@
 require "rails_helper"
 RSpec.describe "GraphQL, signUp mutation", type: :request do
-  let(:query) do
-    <<~QUERY
-      mutation signup(
-        $email: String!,
-        $type: String!
-        $name: String!
-        $surname: String!
-        $phone: String!
-        $address: String!
-        $password: String!,
-        $password_confirmation: String!,
-        ) {
-        signup(
-          input: {
-            name: $name,
-            surname: $surname,
-            phone: $phone,
-            address: $address,
-            type: $type,
-            email: $email,
-            password: $password,
-            passwordConfirmation: $password_confirmation,
-          }
-        ) {
-          user {
-            email
-          }
-          errors
-        }
-      }
-    QUERY
+  context "happy path" do
+    context "when the user is a coach" do
+      it "signs up a new coach successfully" do
+        post "/graphql", params: { query: query_string, variables: variables }, headers: headers
+      end
+    end
+
+    context "when the user is a client" do
+      it "signs up a new client successfully"
+    end
   end
 
-  it "signs up a new user successfully" do
-    post "/graphql", params: {
-      query: query,
-      variables: {
-        name: "Antonio",
-        surname: "Martinez",
-        phone: "987654321",
-        address: "C/ Milladoiro",
-        type: "pepe",
-        email: "pepe21@gmail.com",
-        password: "password",
-        passwordConfirmation: "password"
+  context "unhappy path" do
+    context "when the user is a coach" do
+      context "when the email is already taken"
+      context "when the password is too short"
+      context "when the password confirmation does not match the password"
+    end
+    context "when the user is a client" do
+      context "when the email is already taken"
+      context "when the password is too short"
+      context "when the password confirmation does not match the password"
+    end
+  end
+
+  def mutation(name: nil, surname: nil, phone: nil, address: nil, type: nil, email: nil, password: nil, password_confirmation: nil)
+    <<~GQL
+      mutation {
+        signup(
+          input: {
+            name: "#{name || "null"}",
+            surname: "#{surname || "null"}",
+            phone: "#{phone || "null"}",
+            address: "#{address || "null"}",
+            type: "#{type || "null"}",
+            email: "#{email || "null"}",
+            password: "#{password || "null"}",
+            passwordConfirmation: "#{password_confirmation || "null"}"
+          }) {
+            user {
+              email
+            }
+            errors
+        }
       }
-    }
-    debugger
-    expect(response.parsed_body).not_to have_errors
-    expect(response.parsed_body["data"]).to match(
-      "signup" => {
-        "email" => "test@example.com",
-        "token" => be_present
-      }
-    )
+    GQL
   end
 end


### PR DESCRIPTION
- Add test-specific docker compose configuration, with new service `app_test`.
- Create `Errors::SignUpError` for detailed error handling.
- Refactor sign-up mutation to use error class and simplify return values.
- Update Makefile to include test setup commands.
- Adjust `test` and `test.session` targets.
- Amend `docker-entrypoint` for database setup log.
- Remove `server.pid` file cleanup from `server` and move it to `app` command in `docker-compose.yml`.
- Extend test specs for user sign-up with more scenarios.