### PR TITLE
refactor(authentication): remove unused arguments from SignUp mutation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+# Ignore the frontend, we're using a separate repository for that.
+/frontend
+
 # Ignore bundler config.
 /.bundle
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "frontend"]
-    path = frontend
-    url = https://github.com/Manu-Brais/gym_tracker-frontend
-    branch = main

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,7 @@ install:
 	docker compose run --rm app-test bash -c "\
 	bundle install && \
 	bundle exec rails db:drop db:create db:migrate db:seed"
-	docker compose run --rm frontend bash -c "\
-	npm install --legacy-peer-deps"
+	docker compose run --rm frontend bash -c "npm install"
 
 .PHONY: bundle
 bundle:

--- a/app/graphql/mutations/authentication/sign_up.rb
+++ b/app/graphql/mutations/authentication/sign_up.rb
@@ -1,10 +1,6 @@
 module Mutations
   module Authentication
     class SignUp < BaseMutation
-      argument :name, String, required: true
-      argument :surname, String, required: true
-      argument :phone, String, required: true
-      argument :address, String, required: true
       argument :email, String, required: true
       argument :password, String, required: true
       argument :password_confirmation, String, required: true
@@ -13,8 +9,8 @@ module Mutations
       field :user, Types::UserType, null: true
       field :token, String, null: true
 
-      def resolve(name:, surname:, phone:, address:, email:, password:, password_confirmation:, type:)
-        authenticatable = set_authenticatable(name, surname, phone, address, type)
+      def resolve(email:, password:, password_confirmation:, type:)
+        authenticatable = set_authenticatable(type)
         raise Errors::SignUpError.new(authenticatable.errors.full_messages) unless authenticatable.valid?
 
         user = User.new(
@@ -33,12 +29,12 @@ module Mutations
 
       private
 
-      def set_authenticatable(name, surname, phone, address, type)
+      def set_authenticatable(type)
         case type
         when "coach"
-          Coach.new(name: name, surname: surname, phone: phone, address: address)
+          Coach.new
         when "client"
-          Client.new(name: name, surname: surname, phone: phone, address: address)
+          Client.new
         else
           raise Errors::SignUpError.new("Invalid Authenticatable type, valid types: coach, client")
         end

--- a/app/graphql/types/client_type.rb
+++ b/app/graphql/types/client_type.rb
@@ -1,9 +1,9 @@
 module Types
   class ClientType < BaseObject
     field :id, ID, null: false
-    field :name, String, null: false
-    field :surname, String, null: false
-    field :phone, String, null: false
-    field :address, String, null: false
+    field :name, String, null: true
+    field :surname, String, null: true
+    field :phone, String, null: true
+    field :address, String, null: true
   end
 end

--- a/app/graphql/types/coach_type.rb
+++ b/app/graphql/types/coach_type.rb
@@ -1,9 +1,9 @@
 module Types
   class CoachType < BaseObject
     field :id, ID, null: false
-    field :name, String, null: false
-    field :surname, String, null: false
-    field :phone, String, null: false
-    field :address, String, null: false
+    field :name, String, null: true
+    field :surname, String, null: true
+    field :phone, String, null: true
+    field :address, String, null: true
   end
 end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -2,7 +2,7 @@ module Types
   class UserType < BaseObject
     field :id, ID, null: false
     field :email, String, null: false
-    field :password, String, null: false
+    field :password, String, null: true
 
     field :authenticatable, Types::AuthenticatableType, null: false, method: :authenticatable
   end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,6 +1,3 @@
 class Client < ApplicationRecord
-  # TODO - Add more validations, like phone number, address, etc.
-  validates :name, presence: true
-
   has_one :user, as: :authenticatable, dependent: :destroy
 end

--- a/app/models/coach.rb
+++ b/app/models/coach.rb
@@ -1,6 +1,3 @@
 class Coach < ApplicationRecord
-  # TODO - Add more validations, like phone number, address, etc.
-  validates :name, presence: true
-
   has_one :user, as: :authenticatable, dependent: :destroy
 end

--- a/spec/requests/graphql/mutations/users/sign_up_spec.rb
+++ b/spec/requests/graphql/mutations/users/sign_up_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe "GraphQL, signUp mutation", type: :request do
   subject(:execute_sign_up_mutation) do
     post "/graphql", params: {
       query: mutation(
-        name: name,
-        surname: surname,
-        phone: phone,
-        address: address,
         type: type,
         email: email,
         password: password,
@@ -16,10 +12,6 @@ RSpec.describe "GraphQL, signUp mutation", type: :request do
     }
   end
 
-  let(:name) { "John" }
-  let(:surname) { "Doe" }
-  let(:phone) { "123456789" }
-  let(:address) { "1234 Main St" }
   let(:type) { "coach" }
   let(:email) { "john@doe.com" }
   let(:password) { "password" }
@@ -37,10 +29,7 @@ RSpec.describe "GraphQL, signUp mutation", type: :request do
 
       it "signs up a new coach successfully" do
         expect(response.parsed_body.dig("data", "signup", "user")).to eq({
-          "email" => email,
-          "authenticatable" => {
-            "name" => name
-          }
+          "email" => email
         })
       end
 
@@ -54,10 +43,7 @@ RSpec.describe "GraphQL, signUp mutation", type: :request do
 
       it "signs up a new client successfully" do
         expect(response.parsed_body.dig("data", "signup", "user")).to eq({
-          "email" => email,
-          "authenticatable" => {
-            "name" => name
-          }
+          "email" => email
         })
       end
 
@@ -147,15 +133,11 @@ RSpec.describe "GraphQL, signUp mutation", type: :request do
     end
   end
 
-  def mutation(name: nil, surname: nil, phone: nil, address: nil, type: nil, email: nil, password: nil, password_confirmation: nil)
+  def mutation(type: nil, email: nil, password: nil, password_confirmation: nil)
     <<~GQL
       mutation {
         signup(
           input: {
-            name: "#{name || "null"}",
-            surname: "#{surname || "null"}",
-            phone: "#{phone || "null"}",
-            address: "#{address || "null"}",
             type: "#{type || "null"}",
             email: "#{email || "null"}",
             password: "#{password || "null"}",
@@ -164,14 +146,6 @@ RSpec.describe "GraphQL, signUp mutation", type: :request do
             token
             user {
               email
-              authenticatable {
-                ... on Coach {
-                  name
-                }
-                ... on Client {
-                  name
-                }
-              }
            }
         }
       }


### PR DESCRIPTION
Removed name, surname, phone, and address arguments from the SignUp mutation. Updated the set_authenticatable method to reflect these changes. This simplifies the sign-up process by minimizing the required user information.