### PR TITLE
refactor(authentication): move sign-up logic to service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore the frontend, we're using a separate repository for that.
 /frontend
 
+# Ignore vscode settings.
+.vscode
+
 # Ignore bundler config.
 /.bundle
 

--- a/app/graphql/mutations/authentication/sign_up.rb
+++ b/app/graphql/mutations/authentication/sign_up.rb
@@ -11,50 +11,14 @@ module Mutations
       field :token, String, null: true
 
       def resolve(email:, password:, password_confirmation:, type:, referral_token: nil)
-        authenticatable = set_authenticatable(type)
-        validate_and_reffer_coach(authenticatable, referral_token) if type == "client"
-        raise Errors::SignUpError.new(authenticatable.errors.full_messages) unless authenticatable.valid?
-
-        user = User.new(
-          email: email,
-          password: password,
-          password_confirmation: password_confirmation,
-          authenticatable: authenticatable
-        )
-        raise Errors::SignUpError.new(user.errors.full_messages) unless user.save
+        user = ::Authentication::SignUpService.call(email, password, password_confirmation, type, referral_token)
+        raise Errors::AuthenticationError.new(user.failure) if user.failure?
 
         token = generate_jwt(user)
-        raise Errors::SignUpError.new(token.failure) if token.failure?
-
-        generate_referral_token(authenticatable) if type == "coach"
-        {user: user, token: token.success}
+        {user: user.success, token: token.success}
       end
 
       private
-
-      def set_authenticatable(type)
-        case type
-        when "coach"
-          Coach.new
-        when "client"
-          Client.new
-        else
-          raise Errors::SignUpError.new("Invalid Authenticatable type, valid types: coach, client")
-        end
-      end
-
-      def validate_and_reffer_coach(authenticatable, referral_token)
-        raise Errors::SignUpError.new("Referral token is required for Client type") if referral_token.blank?
-
-        referral = ReferralToken.find_by(id: referral_token)
-        raise Errors::SignUpError.new("Invalid referral token") if referral.blank?
-
-        authenticatable.coach = referral.coach
-      end
-
-      def generate_referral_token(coach)
-        ReferralToken.create(coach: coach)
-      end
 
       def generate_jwt(user)
         ::Authentication::JwtToken::CreateService.call(user, expiration: 7.day.from_now.to_i)

--- a/app/services/authentication/sign_up_service.rb
+++ b/app/services/authentication/sign_up_service.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Authentication
+  class SignUpService < DryService
+    def initialize(email, password, password_confirmation, type, referral_token)
+      @email = email
+      @password = password
+      @password_confirmation = password_confirmation
+      @type = type
+      @referral_token = referral_token
+    end
+
+    def call
+      authenticatable = yield set_authenticatable(@type)
+      yield validate_client_and_refer_coach(authenticatable, @referral_token, @type)
+      user = yield create_user(authenticatable, @email, @password, @password_confirmation)
+      yield generate_referral_token(authenticatable, @type)
+      Success(user)
+    end
+
+    private
+
+    def set_authenticatable(type)
+      case type
+      when "coach"
+        Success(Coach.new)
+      when "client"
+        Success(Client.new)
+      else
+        Failure("Invalid Authenticatable type, valid types: coach, client")
+      end
+    end
+
+    def validate_client_and_refer_coach(authenticatable, referral_token, type)
+      return Success() if type == "coach"
+      return Failure("Referral token is required for Client type") if referral_token.blank?
+
+      referral = ReferralToken.find_by(id: referral_token)
+      return Failure("Invalid referral token") if referral.blank? || referral.coach.blank?
+
+      authenticatable.coach = referral.coach
+      Success()
+    end
+
+    def create_user(authenticatable, email, password, password_confirmation)
+      user = User.new(
+        email: email,
+        password: password,
+        password_confirmation: password_confirmation,
+        authenticatable: authenticatable
+      )
+      return Failure(user.errors.full_messages) unless user.save
+
+      Success(user)
+    end
+
+    def generate_referral_token(coach, type)
+      return Success() if type == "client"
+
+      Try[ActiveRecord::RecordInvalid] { ReferralToken.create(coach: coach) }
+        .to_result
+        .bind { Success() }
+        .or(Failure("Failed to generate referral token"))
+    end
+  end
+end

--- a/spec/requests/graphql/mutations/users/sign_up_spec.rb
+++ b/spec/requests/graphql/mutations/users/sign_up_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "GraphQL, signUp mutation", type: :request do
 
         it "returns an error" do
           expect(response.parsed_body.dig("errors").first.dig("message"))
-            .to eq("[\"Email has already been taken\"]")
+            .to eq("Authentication error: [\"Email has already been taken\"]")
         end
       end
 
@@ -85,7 +85,7 @@ RSpec.describe "GraphQL, signUp mutation", type: :request do
 
         it "returns an error" do
           expect(response.parsed_body.dig("errors").first.dig("message"))
-            .to eq("[\"Password is too short (minimum is 6 characters)\"]")
+            .to eq("Authentication error: [\"Password is too short (minimum is 6 characters)\"]")
         end
       end
 
@@ -96,7 +96,7 @@ RSpec.describe "GraphQL, signUp mutation", type: :request do
 
         it "returns an error" do
           expect(response.parsed_body.dig("errors").first.dig("message"))
-            .to eq("[\"Password confirmation doesn't match Password\"]")
+            .to eq("Authentication error: [\"Password confirmation doesn't match Password\"]")
         end
       end
     end
@@ -109,7 +109,7 @@ RSpec.describe "GraphQL, signUp mutation", type: :request do
 
         it "returns an error" do
           expect(response.parsed_body.dig("errors").first.dig("message"))
-            .to eq("Referral token is required for Client type")
+            .to eq("Authentication error: Referral token is required for Client type")
         end
       end
 
@@ -120,7 +120,7 @@ RSpec.describe "GraphQL, signUp mutation", type: :request do
 
         it "returns an error" do
           expect(response.parsed_body.dig("errors").first.dig("message"))
-            .to eq("Invalid referral token")
+            .to eq("Authentication error: Invalid referral token")
         end
       end
     end


### PR DESCRIPTION
The SignUp mutation now delegates the sign-up process to the `SignUpService`, streamlining the method by removing embedded logic and validations. Updated test cases accordingly to validate new error messages from authentication.

From now on, we will always use a service (A DryService) to perform the operations.