### PR TITLE
feat: integrate solid_queue for job management

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,13 @@ gem "bcrypt"
 gem "dry-monads"
 gem "graphql"
 gem "jwt"
+gem "mission_control-jobs"
 gem "pg"
 gem "puma", ">= 5.0"
 gem "pundit"
 gem "propshaft"
 gem "rack-cors"
+gem "solid_queue"
 gem "tzinfo-data", platforms: %i[windows jruby]
 gem "ruby-ulid", "~> 0.8.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
       dry-core (~> 1.0, < 2)
       zeitwerk (~> 2.6)
     erubi (1.12.0)
+    et-orbi (1.2.11)
+      tzinfo
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.3)
@@ -107,6 +109,9 @@ GEM
       railties (>= 5.0.0)
     faker (3.3.1)
       i18n (>= 1.8.11, < 2)
+    fugit (1.10.1)
+      et-orbi (~> 1, >= 1.2.7)
+      raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
     graphiql-rails (1.10.0)
@@ -115,6 +120,10 @@ GEM
       base64
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
+    importmap-rails (2.0.1)
+      actionpack (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      railties (>= 6.0.0)
     io-console (0.7.2)
     irb (1.12.0)
       rdoc
@@ -135,6 +144,11 @@ GEM
     marcel (1.0.4)
     mini_mime (1.1.5)
     minitest (5.22.3)
+    mission_control-jobs (0.2.1)
+      importmap-rails
+      rails (~> 7.1)
+      stimulus-rails
+      turbo-rails
     mutex_m (0.2.0)
     net-imap (0.4.10)
       date
@@ -174,6 +188,7 @@ GEM
       nio4r (~> 2.0)
     pundit (2.3.2)
       activesupport (>= 3.0.0)
+    raabro (1.4.0)
     racc (1.7.3)
     rack (3.0.10)
     rack-cors (2.0.2)
@@ -261,6 +276,12 @@ GEM
       rubocop-ast (>= 1.30.0, < 2.0)
     ruby-progressbar (1.13.0)
     ruby-ulid (0.8.0)
+    solid_queue (0.3.1)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      concurrent-ruby (~> 1.2.2)
+      fugit (~> 1.10.1)
+      railties (>= 7.1)
     standard (1.35.1)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -273,9 +294,15 @@ GEM
     standard-performance (1.3.1)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.20.2)
+    stimulus-rails (1.3.3)
+      railties (>= 6.0.0)
     stringio (3.1.0)
     thor (1.3.1)
     timeout (0.4.1)
+    turbo-rails (2.0.5)
+      actionpack (>= 6.0.0)
+      activejob (>= 6.0.0)
+      railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -303,6 +330,7 @@ DEPENDENCIES
   graphiql-rails
   graphql
   jwt
+  mission_control-jobs
   pg
   propshaft
   puma (>= 5.0)
@@ -312,6 +340,7 @@ DEPENDENCIES
   rspec
   rspec-rails
   ruby-ulid (~> 0.8.0)
+  solid_queue
   standard
   tzinfo-data
 

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ install:
 
 .PHONY: bundle
 bundle:
-	docker compose run --rm app bundle install
-	docker compose run --rm app-test bundle install
+	docker compose run --rm --no-deps app bundle install
+	docker compose run --rm --no-deps app-test bundle install
 
 .PHONY: console
 console:
@@ -48,7 +48,7 @@ db.session:
 
 .PHONY: standard
 standard:
-	docker compose run --rm app bundle exec standardrb --fix-unsafely
+	docker compose run --rm --no-deps app bundle exec standardrb --fix-unsafely
 
 .PHONY: bash
 bash:

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,7 @@
+class ApplicationJob < ActiveJob::Base
+  # Automatically retry jobs that encountered a deadlock
+  # retry_on ActiveRecord::Deadlocked
+
+  # Most jobs are safe to ignore if the underlying records are no longer available
+  # discard_on ActiveJob::DeserializationError
+end

--- a/app/jobs/test_func_job.rb
+++ b/app/jobs/test_func_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class TestFuncJob < ApplicationJob
+  queue_as :default
+
+  def perform(msg)
+    sleep 2
+    Rails.logger.info "TestFuncJob: #{msg}"
+    puts "TestFuncJob: #{msg}"
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ require "action_controller/railtie"
 # require "action_mailbox/engine"
 # require "action_text/engine"
 require "action_view/railtie"
-# require "action_cable/engine"
+require "action_cable/engine"
 require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,6 +2,7 @@ require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  config.active_job.queue_adapter = :solid_queue
 
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,6 +2,7 @@ require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  config.active_job.queue_adapter = :solid_queue
 
   # Code is not reloaded between requests.
   config.enable_reloading = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
   if Rails.env.development?
     mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"
+    # For testing purposes, mount the MissionControl::Jobs::Engine within this block,
+    # so that the jobs dashboard is only available in development. This could change
+    # when we want to expose the dashboard in production.
+    mount MissionControl::Jobs::Engine, at: "/jobs"
   end
 
   post "/graphql", to: "graphql#execute"

--- a/config/solid_queue.yml
+++ b/config/solid_queue.yml
@@ -1,0 +1,15 @@
+default: &default
+  workers:
+    - queues: "*"
+      threads: 3
+      processes: 1
+      polling_interval: 0.1
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/db/migrate/20240601204027_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20240601204027_create_active_storage_tables.active_storage.rb
@@ -1,10 +1,7 @@
 # This migration comes from active_storage (originally 20170806125915)
 class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
   def change
-    # Use Active Record's configured type for primary and foreign keys
-    primary_key_type, foreign_key_type = primary_and_foreign_key_types
-
-    create_table :active_storage_blobs, id: primary_key_type do |t|
+    create_table :active_storage_blobs, id: :uuid do |t|
       t.string :key, null: false
       t.string :filename, null: false
       t.string :content_type
@@ -22,10 +19,10 @@ class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
       t.index [:key], unique: true
     end
 
-    create_table :active_storage_attachments, id: primary_key_type do |t|
+    create_table :active_storage_attachments, id: :uuid do |t|
       t.string :name, null: false
-      t.references :record, null: false, polymorphic: true, index: false, type: foreign_key_type
-      t.references :blob, null: false, type: foreign_key_type
+      t.references :record, null: false, type: :uuid, polymorphic: true, index: false
+      t.references :blob, null: false, type: :uuid
 
       if connection.supports_datetime_with_precision?
         t.datetime :created_at, precision: 6, null: false
@@ -37,22 +34,12 @@ class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
 
-    create_table :active_storage_variant_records, id: primary_key_type do |t|
-      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+    create_table :active_storage_variant_records, id: :uuid do |t|
+      t.belongs_to :blob, null: false, index: false, type: :uuid
       t.string :variation_digest, null: false
 
       t.index [:blob_id, :variation_digest], name: :index_active_storage_variant_records_uniqueness, unique: true
-      t.foreign_key :active_storage_blobs, column: :blob_id
+      t.foreign_key :active_storage_blob, column: :blob_id
     end
-  end
-
-  private
-
-  def primary_and_foreign_key_types
-    config = Rails.configuration.generators
-    setting = config.options[config.orm][:primary_key_type]
-    primary_key_type = setting || :primary_key
-    foreign_key_type = setting || :bigint
-    [primary_key_type, foreign_key_type]
   end
 end

--- a/db/migrate/20240608175124_create_solid_queue_tables.solid_queue.rb
+++ b/db/migrate/20240608175124_create_solid_queue_tables.solid_queue.rb
@@ -1,0 +1,101 @@
+# This migration comes from solid_queue (originally 20231211200639)
+class CreateSolidQueueTables < ActiveRecord::Migration[7.0]
+  def change
+    create_table :solid_queue_jobs do |t|
+      t.string :queue_name, null: false
+      t.string :class_name, null: false, index: true
+      t.text :arguments
+      t.integer :priority, default: 0, null: false
+      t.string :active_job_id, index: true
+      t.datetime :scheduled_at
+      t.datetime :finished_at, index: true
+      t.string :concurrency_key
+
+      t.timestamps
+
+      t.index [:queue_name, :finished_at], name: "index_solid_queue_jobs_for_filtering"
+      t.index [:scheduled_at, :finished_at], name: "index_solid_queue_jobs_for_alerting"
+    end
+
+    create_table :solid_queue_scheduled_executions do |t|
+      t.references :job, index: {unique: true}, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.datetime :scheduled_at, null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [:scheduled_at, :priority, :job_id], name: "index_solid_queue_dispatch_all"
+    end
+
+    create_table :solid_queue_ready_executions do |t|
+      t.references :job, index: {unique: true}, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [:priority, :job_id], name: "index_solid_queue_poll_all"
+      t.index [:queue_name, :priority, :job_id], name: "index_solid_queue_poll_by_queue"
+    end
+
+    create_table :solid_queue_claimed_executions do |t|
+      t.references :job, index: {unique: true}, null: false
+      t.bigint :process_id
+      t.datetime :created_at, null: false
+
+      t.index [:process_id, :job_id]
+    end
+
+    create_table :solid_queue_blocked_executions do |t|
+      t.references :job, index: {unique: true}, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.string :concurrency_key, null: false
+      t.datetime :expires_at, null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [:expires_at, :concurrency_key], name: "index_solid_queue_blocked_executions_for_maintenance"
+    end
+
+    create_table :solid_queue_failed_executions do |t|
+      t.references :job, index: {unique: true}, null: false
+      t.text :error
+      t.datetime :created_at, null: false
+    end
+
+    create_table :solid_queue_pauses do |t|
+      t.string :queue_name, null: false, index: {unique: true}
+      t.datetime :created_at, null: false
+    end
+
+    create_table :solid_queue_processes do |t|
+      t.string :kind, null: false
+      t.datetime :last_heartbeat_at, null: false, index: true
+      t.bigint :supervisor_id, index: true
+
+      t.integer :pid, null: false
+      t.string :hostname
+      t.text :metadata
+
+      t.datetime :created_at, null: false
+    end
+
+    create_table :solid_queue_semaphores do |t|
+      t.string :key, null: false, index: {unique: true}
+      t.integer :value, default: 1, null: false
+      t.datetime :expires_at, null: false, index: true
+
+      t.timestamps
+
+      t.index [:key, :value], name: "index_solid_queue_semaphores_on_key_and_value"
+    end
+
+    add_foreign_key :solid_queue_blocked_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_claimed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_failed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_ready_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_scheduled_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+  end
+end

--- a/db/migrate/20240608175125_add_missing_index_to_blocked_executions.solid_queue.rb
+++ b/db/migrate/20240608175125_add_missing_index_to_blocked_executions.solid_queue.rb
@@ -1,0 +1,6 @@
+# This migration comes from solid_queue (originally 20240110143450)
+class AddMissingIndexToBlockedExecutions < ActiveRecord::Migration[7.1]
+  def change
+    add_index :solid_queue_blocked_executions, [:concurrency_key, :priority, :job_id], name: "index_solid_queue_blocked_executions_for_release"
+  end
+end

--- a/db/migrate/20240608175126_create_recurring_executions.solid_queue.rb
+++ b/db/migrate/20240608175126_create_recurring_executions.solid_queue.rb
@@ -1,0 +1,15 @@
+# This migration comes from solid_queue (originally 20240218110712)
+class CreateRecurringExecutions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :solid_queue_recurring_executions do |t|
+      t.references :job, index: {unique: true}, null: false
+      t.string :task_key, null: false
+      t.datetime :run_at, null: false
+      t.datetime :created_at, null: false
+
+      t.index [:task_key, :run_at], unique: true
+    end
+
+    add_foreign_key :solid_queue_recurring_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_01_204027) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_08_175126) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -78,6 +78,109 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_01_204027) do
     t.index ["coach_id"], name: "index_referral_tokens_on_coach_id"
   end
 
+  create_table "solid_queue_blocked_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "concurrency_key", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_claimed_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+  end
+
+  create_table "solid_queue_failed_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_jobs", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.string "class_name", null: false
+    t.text "arguments"
+    t.integer "priority", default: 0, null: false
+    t.string "active_job_id"
+    t.datetime "scheduled_at"
+    t.datetime "finished_at"
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
+  end
+
+  create_table "solid_queue_pauses", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.datetime "created_at", null: false
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  end
+
+  create_table "solid_queue_processes", force: :cascade do |t|
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.bigint "supervisor_id"
+    t.integer "pid", null: false
+    t.string "hostname"
+    t.text "metadata"
+    t.datetime "created_at", null: false
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
+  end
+
+  create_table "solid_queue_ready_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
+  end
+
+  create_table "solid_queue_recurring_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "task_key", null: false
+    t.datetime "run_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_scheduled_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "scheduled_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
+  end
+
+  create_table "solid_queue_semaphores", force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "value", default: 1, null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "email", null: false
     t.string "password_digest", null: false
@@ -93,4 +196,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_01_204027) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "clients", "coaches"
   add_foreign_key "referral_tokens", "coaches"
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,15 +9,17 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      solid_queue_worker:
+        condition: service_started
     tty: true
     stdin_open: true
     command: 'bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b 0.0.0.0"'
-    volumes:
+    volumes: &app_volumes
       - .:/rails
       - bundle_data:/usr/local/bundle
     ports:
       - "3000:3000"
-    environment:
+    environment: &app_environment
       RAILS_ENV: development
       DATABASE_URL: postgres://postgres:password@db:5432/gym_trackr_development
       ECDSA_KEY: ${ECDSA_KEY}
@@ -41,6 +43,21 @@ services:
       retries: 3
     ports:
       - "5432:5432"
+
+  solid_queue_worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    stdin_open: true
+    tty: true
+    image: gym_tracker-dev
+    command: bundle exec rake solid_queue:work
+    depends_on:
+      - db
+    networks:
+      - gym_trackr_network
+    volumes: *app_volumes
+    environment: *app_environment
 
   app-test:
     build:


### PR DESCRIPTION
## Description
- Added `solid_queue` gem to Gemfile and Gemfile.lock
- Configured `solid_queue` as the active job queue adapter for production
- Created configuration file for `solid_queue`
- Added database migrations for `solid_queue` tables including jobs, executions, pauses, processes, and semaphores
- Updated schema.rb to include new solid_queue tables and foreign keys

## What does this PR do?
- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Documentation

## What are the relevant issues?
- [x] Jira issue [JIRA](https://gymtrackr.atlassian.net/browse/SCRUM-31)
- [x]  Documentation [Confluence](https://refaktor.atlassian.net/wiki/x/DgCxAQ)

---

## Checklist
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My code follows the code style of this project
  - [Git Style Guide](https://refaktor.atlassian.net/wiki/spaces/GymTrackr/pages/25264131/Git+Guidelines)
  - [Code Review Guidelines](https://refaktor.atlassian.net/wiki/spaces/GymTrackr/pages/25067538/Code+Review+Guidelines)
