### PR TITLE
refactor(auth): remove user information from responses

### DIFF
--- a/app/graphql/mutations/public/authentication/log_in.rb
+++ b/app/graphql/mutations/public/authentication/log_in.rb
@@ -17,7 +17,7 @@ module Mutations
 
           raise Errors::LogInError.new(token.failure) if token.failure?
 
-          {token: token.success, user: user}
+          {token: token.success}
         end
 
         private

--- a/app/graphql/mutations/public/authentication/sign_up.rb
+++ b/app/graphql/mutations/public/authentication/sign_up.rb
@@ -15,7 +15,7 @@ module Mutations
           user = sign_up_user(email, password, password_confirmation, type, referral_token)
           token = generate_jwt(user)
 
-          {user: user, token: token}
+          {token: token}
         end
 
         private

--- a/app/services/authentication/jwt_token/create_service.rb
+++ b/app/services/authentication/jwt_token/create_service.rb
@@ -33,6 +33,7 @@ module Authentication
         Try do
           {
             user_id: user.id,
+            user_type: user.coach? ? "coach" : "client",
             valid_for: TOKEN_PURPOSE,
             exp: expiration
           }

--- a/spec/requests/graphql/mutations/users/log_in_spec.rb
+++ b/spec/requests/graphql/mutations/users/log_in_spec.rb
@@ -78,9 +78,6 @@ RSpec.describe "GraphQL, logIn mutation", type: :request do
             email: "#{email || "null"}",
             password: "#{password || "null"}"
           }) {
-            user {
-              email
-            }
             token
         }
       }

--- a/spec/requests/graphql/mutations/users/sign_up_spec.rb
+++ b/spec/requests/graphql/mutations/users/sign_up_spec.rb
@@ -28,12 +28,6 @@ RSpec.describe "GraphQL, signUp mutation", type: :request do
     context "when the user is a coach" do
       let(:type) { "coach" }
 
-      it "signs up a new coach successfully" do
-        expect(response.parsed_body.dig("data", "signup", "user")).to eq({
-          "email" => email
-        })
-      end
-
       it "returns the token" do
         expect(response.parsed_body.dig("data", "signup", "token")).to be_present
       end
@@ -44,12 +38,6 @@ RSpec.describe "GraphQL, signUp mutation", type: :request do
       let(:referral) { create(:referral_token, coach: coach.authenticatable) }
       let(:type) { "client" }
       let(:referral_token) { referral.id }
-
-      it "signs up a new client successfully" do
-        expect(response.parsed_body.dig("data", "signup", "user")).to eq({
-          "email" => email
-        })
-      end
 
       it "returns the token" do
         expect(response.parsed_body.dig("data", "signup", "token")).to be_present
@@ -138,9 +126,6 @@ RSpec.describe "GraphQL, signUp mutation", type: :request do
             referralToken: "#{referral_token}"
           }) {
             token
-            user {
-              email
-           }
         }
       }
     GQL


### PR DESCRIPTION
## Description
- In `log_in` and `sign_up` mutations, removed user from response.
- Updated JWT token creation service to include `user_type` information.
- Adjusted test cases to no longer expect user data in the responses.

## What does this PR do?
- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## What are the relevant issues?
- [ ] Jira issue [JIRA]()

---

## Checklist
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] My code follows the code style of this project
  - [Git Style Guide](https://refaktor.atlassian.net/wiki/spaces/GymTrackr/pages/25264131/Git+Guidelines)
  - [Code Review Guidelines](https://refaktor.atlassian.net/wiki/spaces/GymTrackr/pages/25067538/Code+Review+Guidelines)
