### PR TITLE
feat(exercises): add delete and update exercise functionality

### DIFF
--- a/app/graphql/mutations/protected/coach/exercises/delete_exercise.rb
+++ b/app/graphql/mutations/protected/coach/exercises/delete_exercise.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Protected
+    module Coach
+      module Exercises
+        class DeleteExercise < ProtectedMutation
+          argument :id, ID, required: true
+
+          field :success, Boolean, null: false
+
+          def resolve(id:)
+            authorize!(current_user, :create_exercise?)
+            result = ::Exercises::DeleteService.call(
+              current_user.authenticatable_id,
+              id
+            )
+
+            raise Errors::ExerciseDeleteError, result.failure if result.failure?
+
+            {success: true}
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/protected/coach/exercises/update_exercise.rb
+++ b/app/graphql/mutations/protected/coach/exercises/update_exercise.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Protected
+    module Coach
+      module Exercises
+        class UpdateExercise < ProtectedMutation
+          argument :id, ID, required: true
+          argument :title, String, required: false
+          argument :description, String, required: false
+          argument :video_file, ApolloUploadServer::Upload, required: false
+
+          field :exercise, Types::ExerciseType, null: false
+
+          def resolve(id:, title: nil, description: nil, video_file: nil)
+            authorize!(current_user, :create_exercise?)
+            result = ::Exercises::UpdateService.call(
+              current_user.authenticatable_id,
+              id,
+              title,
+              description,
+              video_file
+            )
+
+            raise Errors::ExerciseUpdateError, result.failure if result.failure?
+
+            {exercise: result.success}
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -1,6 +1,6 @@
 class Exercise < ApplicationRecord
   after_update :notify_status_change, if: :saved_change_to_video_status?
-  after_destroy_commit { video.attachment.purge }
+  after_destroy_commit { video.attachment&.purge }
 
   has_one_attached :video, dependent: :purge
   belongs_to :coach

--- a/app/services/exercises/delete_service.rb
+++ b/app/services/exercises/delete_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Exercises
+  class DeleteService < DryService
+    def initialize(coach_id, id)
+      @coach_id = coach_id
+      @id = id
+    end
+
+    def call
+      exercise = yield find_exercise
+      yield delete_exercise(exercise)
+      Success(true)
+    end
+
+    private
+
+    def find_exercise
+      Try[ActiveRecord::RecordNotFound] do
+        coach = Coach.find(@coach_id)
+        coach.exercises.find(@id)
+      end.or { |e| Failure(e) }
+    end
+
+    def delete_exercise(exercise)
+      Try[ActiveRecord::RecordNotDestroyed] do
+        exercise.destroy!
+      end
+        .bind { Success() }
+        .or { |e| Failure("Error deleting exercise #{exercise.id}") }
+    end
+  end
+end

--- a/app/services/exercises/update_service.rb
+++ b/app/services/exercises/update_service.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Exercises
+  class UpdateService < DryService
+    def initialize(coach_id, id, title, description, video_file)
+      @coach_id = coach_id
+      @id = id
+      @title = title
+      @description = description
+      @video_file = video_file
+    end
+
+    def call
+      exercise = yield find_exercise
+      updated_exercise = yield update_exercise(exercise)
+      if @video_file
+        tmp_video = yield save_tmp_video(@video_file)
+        enqueue_video_processing(updated_exercise, tmp_video)
+      else
+        Success(updated_exercise)
+      end
+    end
+
+    private
+
+    def find_exercise
+      Try[ActiveRecord::RecordNotFound] do
+        coach = Coach.find(@coach_id)
+        coach.exercises.find(@id)
+      end.or { |e| Failure(e) }
+    end
+
+    def update_exercise(exercise)
+      update_params = {}
+      update_params[:title] = @title unless @title.nil?
+      update_params[:description] = @description unless @description.nil?
+      update_params[:video_status] = :initialized if @video_file
+
+      Try[ActiveRecord::RecordInvalid] do
+        exercise.update!(update_params)
+        exercise
+      end.or { |e| Failure(e.record.errors.full_messages) }
+    end
+
+    def save_tmp_video(video_file)
+      Try[Errno::ENOENT] do
+        video_path = "#{Rails.root}/tmp/#{video_file.original_filename}"
+        File.binwrite(video_path, video_file.read)
+
+        video_path
+      end.or { |e| Failure(e) }
+    end
+
+    def enqueue_video_processing(exercise, video_path)
+      ExercisesProcessingJob.perform_later(exercise.id, video_path)
+
+      update_result = Try[ActiveRecord::RecordInvalid] do
+        exercise.update!(video_status: :enqueued)
+      end
+
+      update_result
+        .bind { Success(exercise) }
+        .or { |e| Failure(e) }
+    end
+  end
+end

--- a/spec/services/exercises/delete_service_spec.rb
+++ b/spec/services/exercises/delete_service_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+RSpec.describe Exercises::DeleteService do
+  subject(:service) { described_class.call(coach.id, exercise.id) }
+
+  let(:coach) { create(:coach) }
+  let(:exercise) { create(:exercise, coach: coach) }
+
+  describe "#call" do
+    context "when exercise is successfully deleted" do
+      it "returns Success(true)" do
+        result = service
+
+        expect(result).to be_success
+        expect(result.success).to be true
+        expect { Exercise.find(exercise.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when exercise does not exist" do
+      let(:nonexistent_id) { 0 }
+      subject(:service) { described_class.call(coach.id, nonexistent_id) }
+
+      it "returns a Failure monad with the error message" do
+        expect(service).to be_failure
+        expect(service.failure.message).to include("Couldn't find Exercise")
+      end
+    end
+
+    context "when exercise belongs to another coach" do
+      let(:another_coach) { create(:coach) }
+      subject(:service) { described_class.call(another_coach.id, exercise.id) }
+
+      it "returns a Failure monad with the error message" do
+        expect(service).to be_failure
+        expect(service.failure.message).to include("Couldn't find Exercise")
+      end
+    end
+
+    context "when exercise deletion fails" do
+      before do
+        allow(Coach).to receive(:find).and_return(coach)
+        allow(coach.exercises).to receive(:find).and_return(exercise)
+        allow(exercise).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed, exercise)
+        exercise.errors.add(:base, "Failed to destroy the record")
+      end
+
+      it "returns a Failure monad with the error message" do
+        expect(service).to be_failure
+        expect(service.failure).to include("Error deleting exercise #{exercise.id}")
+      end
+    end
+  end
+end

--- a/spec/services/exercises/update_service_spec.rb
+++ b/spec/services/exercises/update_service_spec.rb
@@ -1,0 +1,68 @@
+require "spec_helper"
+
+RSpec.describe Exercises::UpdateService do
+  subject(:service) { described_class.call(coach.id, exercise.id, title, description, video_file) }
+
+  let(:coach) { create(:coach) }
+  let(:exercise) { create(:exercise, coach: coach) }
+  let(:title) { "Updated Exercise Title" }
+  let(:description) { "Updated Exercise Description" }
+  let(:video_file) { double(:video_file, original_filename: "updated_video.mp4", read: "video content") }
+
+  describe "#call" do
+    context "when all steps succeed" do
+      before do
+        allow(File).to receive(:binwrite)
+        allow(ExercisesProcessingJob).to receive(:perform_later)
+      end
+
+      it "returns the exercise in state :enqueued" do
+        result = service
+
+        expect(result).to be_success
+        expect(result.success).to have_attributes(
+          id: exercise.id,
+          title: title,
+          description: description,
+          video_status: "enqueued"
+        )
+      end
+    end
+
+    context "when exercise is not found" do
+      let(:coach_with_no_exercises) { create(:coach) }
+      subject(:service) { described_class.call(coach_with_no_exercises.id, exercise.id, title, description, video_file) }
+
+      it "returns a Failure monad with the error message" do
+        expect(service).to be_failure
+        expect(service.failure.message).to include("Couldn't find Exercise with 'id'")
+      end
+    end
+
+    context "when exercise update fails" do
+      let(:title) { nil }
+      let(:description) { nil }
+
+      before do
+        allow_any_instance_of(Exercise).to receive(:update!).and_raise(ActiveRecord::RecordInvalid, exercise)
+        exercise.errors.add(:title, "There was an error")
+      end
+
+      it "returns a Failure monad with the error message" do
+        expect(service).to be_failure
+        expect(service.failure).to include("Title There was an error")
+      end
+    end
+
+    context "when video file saving fails" do
+      before do
+        allow(File).to receive(:binwrite).and_raise(Errno::ENOENT)
+      end
+
+      it "returns a Failure monad with the error message" do
+        expect(service).to be_failure
+        expect(service.failure.message).to include("No such file or directory")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
- Added `delete_exercise` mutation to delete an exercise.
- Added `update_exercise` mutation to update exercise attributes.
- Implemented `DeleteService` to handle exercise deletion logic.
- Implemented `UpdateService` to handle exercise update logic and video processing.
- Updated `Exercise` model to use safe attachment purging.
- Added specs for `DeleteService` and `UpdateService` to cover various scenarios.


## What does this PR do?
- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Documentation

## What are the relevant issues?
- [x] Jira issue [JIRA](https://gymtrackr.atlassian.net/browse/SCRUM-49)
- [x] Jira issue [JIRA](https://gymtrackr.atlassian.net/browse/SCRUM-50)

---

## Checklist
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My code follows the code style of this project
  - [Git Style Guide](https://refaktor.atlassian.net/wiki/spaces/GymTrackr/pages/25264131/Git+Guidelines)
  - [Code Review Guidelines](https://refaktor.atlassian.net/wiki/spaces/GymTrackr/pages/25067538/Code+Review+Guidelines)
