### PR TITLE
feat(graphql): implement pagination for exercises query

### DIFF
--- a/app/graphql/queries/protected/coach/exercises_query.rb
+++ b/app/graphql/queries/protected/coach/exercises_query.rb
@@ -7,7 +7,7 @@ module Queries
         extend ActiveSupport::Concern
 
         included do
-          field :exercises, [Types::ExerciseType], null: false
+          field :exercises, Types::ExerciseConnectionType, null: false, connection: true
 
           def exercises
             authenticate_user!

--- a/app/graphql/types/exercise_connection_type.rb
+++ b/app/graphql/types/exercise_connection_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  class ExerciseConnectionType < Types::BaseObject
+    field :edges, [Types::ExerciseEdgeType], null: false
+    field :page_info, Types::PageInfoType, null: false
+    field :total_count, Integer, null: false
+
+    def total_count
+      object.items.size
+    end
+  end
+end

--- a/app/graphql/types/exercise_edge_type.rb
+++ b/app/graphql/types/exercise_edge_type.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Types
+  class ExerciseEdgeType < Types::BaseObject
+    field :node, Types::ExerciseType, null: false
+    field :cursor, String, null: false
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -5,6 +5,8 @@ module Types
     field :signup, mutation: Mutations::Public::Authentication::SignUp
     field :login, mutation: Mutations::Public::Authentication::LogIn
     field :create_exercise, mutation: Mutations::Protected::Coach::Exercises::CreateExercise
+    field :delete_exercise, mutation: Mutations::Protected::Coach::Exercises::DeleteExercise
+    field :update_exercise, mutation: Mutations::Protected::Coach::Exercises::UpdateExercise
     field :update_user_data, mutation: Mutations::Protected::User::UpdateUserData
   end
 end

--- a/app/graphql/types/page_info_type.rb
+++ b/app/graphql/types/page_info_type.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Types
+  class PageInfoType < Types::BaseObject
+    field :end_cursor, String, null: true
+    field :start_cursor, String, null: true
+    field :has_next_page, Boolean, null: false
+    field :has_previous_page, Boolean, null: false
+  end
+end

--- a/spec/requests/graphql/queries/coach/exercises_spec.rb
+++ b/spec/requests/graphql/queries/coach/exercises_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe "GraphQL, exercises Query", type: :request do
       end
 
       it "returns the coach data" do
-        expect(response.parsed_body.dig("data", "exercises").first.dig("videoUrl")).to eq("videoUrl")
-        expect(response.parsed_body.dig("data", "exercises")).to match_array(
+        expect(response.parsed_body.dig("data", "exercises", "edges").first.dig("node", "videoUrl")).to eq("videoUrl")
+        expect(response.parsed_body.dig("data", "exercises", "edges").first.dig("node")).to match(
           a_hash_including(
             "description" => "Exercise Description",
             "title" => "Exercise Title",
@@ -61,10 +61,14 @@ RSpec.describe "GraphQL, exercises Query", type: :request do
     <<~GQL
       query {
         exercises {
-          description
-          title
-          videoStatus
-          videoUrl
+          edges {
+            node {
+              description
+              title
+              videoStatus
+              videoUrl
+            }
+          }
         }
       }
     GQL


### PR DESCRIPTION
## Description
- Changed `exercises` field to use `ExerciseConnectionType` for pagination
- Added `ExerciseConnectionType` with fields `edges`, `page_info`, and `total_count`
- Introduced `ExerciseEdgeType` to represent individual exercise nodes and cursors
- Added `PageInfoType` to encapsulate pagination cursors and page information

## What does this PR do?
- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Documentation

## What are the relevant issues?
- [x] Jira issue [JIRA](https://gymtrackr.atlassian.net/browse/SCRUM-52)
- [x] Confluence documentation [CONFLUENCE](https://refaktor.atlassian.net/wiki/spaces/GymTrackr/pages/33488898/GraphQL+Pagination)

---

## Checklist
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My code follows the code style of this project
  - [Git Style Guide](https://refaktor.atlassian.net/wiki/spaces/GymTrackr/pages/25264131/Git+Guidelines)
  - [Code Review Guidelines](https://refaktor.atlassian.net/wiki/spaces/GymTrackr/pages/25067538/Code+Review+Guidelines)
